### PR TITLE
version 2 with extension memos and higher reliance on extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,9 +423,9 @@ If the extension uses state to keep track of values it has marked as
 candidates, it can use that state in conjunction with the optional
 `shouldSerialise` method to determine if an extension should be applied to the
 value. `shouldSerialise` will only ever be called once all candidates have been
-determined (see Extensions and Recursion for an exception to this). If
-`shouldSerialise` is not provided, the extension behaves as if it was given a
-function which always returns `true`.
+determined (see Extensions and Recursion for an exception to this). This is
+useful for optimisations that need to see all of the data being encoded before
+being effective. Most extensions will always return `true` from this function.
 
 ### Extension memos
 
@@ -461,11 +461,11 @@ class SymbolExtension {
 let encoded = encode(data, { extensions: { 0: SymbolExtension } });
 ```
 
-Memos are only prepended for extensions that define the optional `memo`
-function. Memos are encoded and prepended to the SuperPack payload in
-descending extension point order. During the encoding of a memo, extensions
-that define the optional `memo` function must not be applied if their extension
-point is greater than that of the extension whose memo is being encoded.
+Memos are encoded and prepended to the SuperPack payload in descending
+extension point order. Memos are only prepended for extensions that indicate
+that they require a memo. During the encoding of a memo, extensions that use a
+memo must not be applied if their extension point is greater than that of the
+extension whose memo is being encoded.
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -8,18 +8,20 @@ booleans, strings used more than once, objects which have the same shape, etc.
 A comparison of schemaless serialisation formats run on 1000 [public domain book records](https://www.npmjs.com/package/public-domain-nypl-captures)
 from the [New York Public Library Digital Collections API](http://api.repo.nypl.org/):
 
-| name                                                                 | encoded size | gzip compressed | extensible | rich built-in types | human-readable |
-| -------------------------------------------------------------------- | -----------: | --------------: | ---------- | ------------------- | -------------- |
-| *SuperPack*<sup>1</sup>                                              |      768121B |         225789B | YES        | no                  | no             |
-| [Sereal](https://github.com/Sereal/Sereal)                           |     1442191B |         268279B | YES        | no                  | no             |
-| [MessagePack](http://msgpack.org)                                    |     2019749B |         271652B | YES        | no                  | no             |
-| *SuperPack*<sup>2</sup>                                              |     2024460B |         264545B | YES        | no                  | no             |
-| [CBOR](http://cbor.io/)                                              |     2025561B |         270380B | YES        | YES                 | no             |
-| [bencode](https://wiki.theory.org/BitTorrentSpecification#Bencoding) |     2208153B |         273791B | no         | no                  | arguably       |
-| [edn](https://github.com/edn-format/edn)                             |     2257810B |         261175B | YES        | no                  | YES            |
-| [JSON](http://www.json.org/)                                         |     2275987B |         260878B | no         | no                  | arguably       |
-| [BSON](http://bsonspec.org/)                                         |     2353043B |         314438B | YES        | YES                 | no             |
-| [YAML](http://yaml.org/)                                             |     2444730B |         275741B | YES        | no                  | YES            |
+| name                                                                 | encoded size | gzip compressed | extensible    | rich built-in types | human-readable |
+| -------------------------------------------------------------------- | -----------: | --------------: | ----------    | ------------------- | -------------- |
+| *SuperPack*<sup>1</sup>                                              |      768121B |         225789B | YES           | no                  | no             |
+| [Sereal](https://github.com/Sereal/Sereal)                           |     1442191B |         268279B | YES           | no                  | no             |
+| [MessagePack](http://msgpack.org)                                    |     2019749B |         271652B | YES           | no                  | no             |
+| *SuperPack*<sup>2</sup>                                              |     2024460B |         264545B | YES           | no                  | no             |
+| [CBOR](http://cbor.io/)                                              |     2025561B |         270380B | YES           | YES                 | no             |
+| [ARSON](https://github.com/benjamn/arson)                            |     2048144B |         361479B | theoretically | YES                 | arguably       |
+| [bencode](https://wiki.theory.org/BitTorrentSpecification#Bencoding) |     2208153B |         273791B | no            | no                  | arguably       |
+| [edn](https://github.com/edn-format/edn)                             |     2257810B |         261175B | YES           | no                  | YES            |
+| [JSON](http://www.json.org/)                                         |     2275987B |         260878B | no            | no                  | arguably       |
+| [BSON](http://bsonspec.org/)                                         |     2353043B |         314438B | YES           | YES                 | no             |
+| [YAML](http://yaml.org/)                                             |     2444730B |         275741B | YES           | no                  | YES            |
+
 
 SuperPack is designed to
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@ booleans, strings used more than once, objects which have the same shape, etc.
 A comparison of schemaless serialisation formats run on 1000 [public domain book records](https://www.npmjs.com/package/public-domain-nypl-captures)
 from the [New York Public Library Digital Collections API](http://api.repo.nypl.org/):
 
-**TODO: split into SuperPack with no optimisations and SuperPack with only built-in optimisations**
-
 | name                                                                 | encoded size | gzip compressed | extensible | rich built-in types | human-readable |
 | -------------------------------------------------------------------- | -----------: | --------------: | ---------- | ------------------- | -------------- |
-| *SuperPack*                                                          |      810411B |         224534B | YES        | no                  | no             |
-| [Sereal](https://github.com/Sereal/Sereal)                           |     1438974B |         263877B | YES        | no                  | no             |
+| *SuperPack*<sup>1</sup>                                              |      768121B |         225789B | YES        | no                  | no             |
+| [Sereal](https://github.com/Sereal/Sereal)                           |     1442191B |         268279B | YES        | no                  | no             |
 | [MessagePack](http://msgpack.org)                                    |     2019749B |         271652B | YES        | no                  | no             |
+| *SuperPack*<sup>2</sup>                                              |     2024460B |         264545B | YES        | no                  | no             |
 | [CBOR](http://cbor.io/)                                              |     2025561B |         270380B | YES        | YES                 | no             |
 | [bencode](https://wiki.theory.org/BitTorrentSpecification#Bencoding) |     2208153B |         273791B | no         | no                  | arguably       |
 | [edn](https://github.com/edn-format/edn)                             |     2257810B |         261175B | YES        | no                  | YES            |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ from the [New York Public Library Digital Collections API](http://api.repo.nypl.
 | [BSON](http://bsonspec.org/)                                         |     2353.0KB |         314.4KB | YES           | YES                 | no             |
 | [YAML](http://yaml.org/)                                             |     2444.7KB |         275.7KB | YES           | no                  | YES            |
 
+1. with built-in optimisations enabled
+1. with no optimisations enabled
+
 
 SuperPack is designed to
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # SuperPack
 
-SuperPack is a data serialisation format. Due to its design and its [optional optimisations](#optimisations),
-it is particularly suitable for encoding values with repeated structure: arrays
-of booleans, strings used more than once, objects which have the same shape,
-etc.
+SuperPack is a data serialisation format. Due to its design and the
+optimisations enabled by its [extension mechanism](#extensions), it is
+particularly suitable for encoding values with repeated structure: arrays of
+booleans, strings used more than once, objects which have the same shape, etc.
 
 A comparison of schemaless serialisation formats run on 1000 [public domain book records](https://www.npmjs.com/package/public-domain-nypl-captures)
 from the [New York Public Library Digital Collections API](http://api.repo.nypl.org/):
+
+**TODO: split into SuperPack with no optimisations and SuperPack with only built-in optimisations**
 
 | name                                                                 | encoded size | gzip compressed | extensible | rich built-in types | human-readable |
 | -------------------------------------------------------------------- | -----------: | --------------: | ---------- | ------------------- | -------------- |
@@ -22,84 +24,76 @@ from the [New York Public Library Digital Collections API](http://api.repo.nypl.
 
 SuperPack is designed to
 
-  * achieve a small encoded payload size
-  * have a reasonably small transcoder
-  * encode data of an (a priori) unknown schema
-  * transcode arbitrary data types without consulting the SuperPack authors through [extension](#extension)
-  * operate in an environment without access to a lossless data compression algorithm
+* achieve a small encoded payload size
+* have a reasonably small transcoder
+* encode data of an (a priori) unknown schema
+* transcode arbitrary data types without consulting the SuperPack authors by
+  using the [extension](#extensions) capabilities
+* operate in an environment without access to a lossless data compression algorithm
 
 
 ## Overview
 
 ### Terminology and Requirements
 
-The SuperPack format specifies 255 *type tags* for representing values of various data types.
+The SuperPack format specifies 256 *type tags* for representing values of
+various data types.
 
-A *SuperPack value* starts with a type tag and can be encoded or decoded without backtracking.
+A *SuperPack value* is an encoded representation of a value. It starts with a
+type tag and can be decoded without backtracking. The number of bytes that
+comprise the SuperPack value may not be known until it is fully decoded.
 
-A *SuperPack payload* is a byte sequence representing one *SuperPack value*.
+A *SuperPack payload* is a byte sequence containing one SuperPack value,
+prepended by up to one SuperPack value for each enabled extension.
 
-A SuperPack encoder is a function from a value to a SuperPack payload.
-A SuperPack decoder is a function from a SuperPack payload to a value.
+A SuperPack encoder is a function from a value to a SuperPack payload. A
+SuperPack decoder is a function from a SuperPack payload to a value.
 
-The SuperPack format allows for two optional optimisations: the *repeated string optimisation* and the *repeated keyset optimisation*. Since some values do not benefit from these optimisations, a *SuperPack payload* can have two forms:
+- When a value has more than one equivalent representation (e.g. the integer 0
+  as uint6, uint14, nint4, etc.), a SuperPack encoder may produce any
+  applicable representation.
+- When a value has more than one equivalent representaion, a SuperPack encoder
+  should produce a SuperPack value with the shortest length possible.
+- A SuperPack encoder is not required to produce all possible SuperPack values
+  (it may always use str\* for strings, etc).
+- A SuperPack decoder must be able to decode any SuperPack value.
 
-- Simple: the byte array contains just the value; neither optimisation is used.
-- Optimised: the byte array contains multiple parts which are used to reconstruct the value; one or both optimisations MAY be used. See the [Optimisations](#optimisations) section for more details on the optimised form.
+### Type Tags
 
-It is considered somewhat more complex to encode to the optimised form than to the simple form, but it remains comparatively easy to decode optimised form payloads.
-Additionally, an encoder can still be a total function without supporting the optimised form, but a decoder cannot be a total function without supporting it. As a result,
-
-- Encoders SHOULD support the optimised form to make best use of the SuperPack format
-- Encoders MAY forego optimisations for simplicity (i.e. always use the simple form)
-- Decoders MUST support decoding both the simple and optimised forms
-
-SuperPack also supports efficient storage of booleans in boolean-valued homogeneous structures via the `barray` and `bmap` types. Encoders SHOULD support these types, and decoders MUST support decoding them.
-
-The keys of `map` and `bmap` values MUST be strings (like JSON) and they MUST be unique (unlike JSON). This simplifies the repeated keyset optimisation process and allows it to benefit from the repeated string optimisation.
-
-### Type tags
-
-| Hex  | Dec | Binary   | Tag Name                |
-| ---- | --- | -------- | ----------------------- |
-| 0x00 |   0 | 00------ | [uint6](#uint6)         |
-| 0x40 |  64 | 01------ | [uint14](#uint14)       |
-| 0x80 | 128 | 1000---- | [nint4](#nint4)         |
-| 0x90 | 144 | 1001---- | [barray4](#barray4)     |
-| 0xA0 | 160 | 101----- | [array5](#array5)       |
-| 0xC0 | 192 | 110----- | [str5](#str5)           |
-| 0xE0 | 224 | 11100000 | [false](#false)         |
-| 0xE1 | 225 | 11100001 | [true](#true)           |
-| 0xE2 | 226 | 11100010 | [null](#null)           |
-| 0xE3 | 227 | 11100011 | [undefined](#undefined) |
-| 0xE4 | 228 | 11100100 | [uint16](#uint16)       |
-| 0xE5 | 229 | 11100101 | [uint24](#uint24)       |
-| 0xE6 | 230 | 11100110 | [uint32](#uint32)       |
-| 0xE7 | 231 | 11100111 | [uint64](#uint64)       |
-| 0xE8 | 232 | 11101000 | [nint8](#nint8)         |
-| 0xE9 | 233 | 11101001 | [nint16](#nint16)       |
-| 0xEA | 234 | 11101010 | [nint32](#nint32)       |
-| 0xEB | 235 | 11101011 | [nint64](#nint64)       |
-| 0xEC | 236 | 11101100 | [float32](#float32)     |
-| 0xED | 237 | 11101101 | [double64](#double64)   |
-| 0xEE | 238 | 11101110 | [timestamp](#timestamp) |
-| 0xEF | 239 | 11101111 | [binary\*](#binary)     |
-| 0xF0 | 240 | 11110000 | [cstring](#cstring)     |
-| 0xF1 | 241 | 11110001 | [str8](#str8)           |
-| 0xF2 | 242 | 11110010 | [str\*](#str)           |
-| 0xF3 | 243 | 11110011 | [strref](#strref)       |
-| 0xF4 | 244 | 11110100 | [array8](#array8)       |
-| 0xF5 | 245 | 11110101 | [array\*](#array)       |
-| 0xF6 | 246 | 11110110 | [barray8](#barray8)     |
-| 0xF7 | 247 | 11110111 | [barray\*](#barray)     |
-| 0xF8 | 248 | 11111000 | [map](#map)             |
-| 0xF9 | 249 | 11111001 | [bmap](#bmap)           |
-| 0xFA | 250 | 11111010 | [mapl](#mapl)           |
-| 0xFB | 251 | 11111011 | [bmapl](#bmapl)         |
-| 0xFC | 252 | 11111100 | unused                  |
-| 0xFD | 253 | 11111101 | unused                  |
-| 0xFE | 254 | 11111110 | [opts](#optimisations)  |
-| 0xFF | 255 | 11111111 | [extension](#extension) |
+| Hex  | Dec | Binary   | Tag Name                  |
+| ---- | --- | -------- | ------------------------- |
+| 0x00 |   0 | 00------ | [uint6](#uint6)           |
+| 0x40 |  64 | 01------ | [uint14](#uint14)         |
+| 0x80 | 128 | 10000000 | RESERVED                  |
+| 0x81 | 129 | 1000---- | [nint4](#nint4)           |
+| 0x90 | 144 | 1001---- | [barray4](#barray4)       |
+| 0xA0 | 160 | 101----- | [array5](#array5)         |
+| 0xC0 | 192 | 110----- | [str5](#str5)             |
+| 0xE0 | 224 | 11100000 | [false](#false)           |
+| 0xE1 | 225 | 11100001 | [true](#true)             |
+| 0xE2 | 226 | 11100010 | [null](#null)             |
+| 0xE3 | 227 | 11100011 | [undefined](#undefined)   |
+| 0xE4 | 228 | 11100100 | [uint16](#uint16)         |
+| 0xE5 | 229 | 11100101 | [uint24](#uint24)         |
+| 0xE6 | 230 | 11100110 | [uint32](#uint32)         |
+| 0xE7 | 231 | 11100111 | [uint64](#uint64)         |
+| 0xE8 | 232 | 11101000 | [nint8](#nint8)           |
+| 0xE9 | 233 | 11101001 | [nint16](#nint16)         |
+| 0xEA | 234 | 11101010 | [nint32](#nint32)         |
+| 0xEB | 235 | 11101011 | [nint64](#nint64)         |
+| 0xEC | 236 | 11101100 | [float32](#float32)       |
+| 0xED | 237 | 11101101 | [double64](#double64)     |
+| 0xEE | 238 | 11101110 | [timestamp](#timestamp)   |
+| 0xEF | 239 | 11101111 | [binary\*](#binary)       |
+| 0xF0 | 240 | 11110000 | [cstring](#cstring)       |
+| 0xF1 | 241 | 11110001 | [str\*](#str)             |
+| 0xF2 | 242 | 11110010 | [array\*](#array)         |
+| 0xF3 | 243 | 11110011 | [barray\*](#barray)       |
+| 0xF4 | 244 | 11110100 | [map](#map)               |
+| 0xF5 | 245 | 11110101 | [bmap](#bmap)             |
+| 0xF6 | 246 | 11110110 | RESERVED                  |
+| 0xF7 | 247 | 11110111 | [extension\*](#extension) |
+| 0xF8 | 251 | 11111--- | [extension3](#extension3) |
 
 
 ## Type Breakdown
@@ -107,7 +101,9 @@ The keys of `map` and `bmap` values MUST be strings (like JSON) and they MUST be
 #### Notational Conventions
 
 * `0x00` represents a byte as the hexadecimal number following `0x`.
-* `xxxxxxxx` represents a byte as 8 bits. Some `x`s may instead be `0` or `1` to indicate that those bits are fixed. Remaining `x` bits may be either `0` or `1`.
+* `xxxxxxxx` represents a byte as 8 bits. Some `x`s may instead be `0` or `1`
+  to indicate that those bits are fixed. Remaining `x` bits may be either `0`
+  or `1`.
 * Boxes with `--------` borders are drawn around one of the above single byte values.
 * Boxes with `========` borders are drawn around zero or more bytes as described within.
 * Boxes with `~~~~~~~~` borders are drawn around zero or more SuperPack encoded values.
@@ -130,7 +126,7 @@ An integer between 0 and 63.
     |01xxxxxx|xxxxxxxx|
     +--------+--------+
 
-An integer between 0 and 16,383 (2^14 - 1).
+An integer between 64 and 16,383 (2<sup>14</sup> - 1).
 
 #### uint16
 
@@ -138,7 +134,7 @@ An integer between 0 and 16,383 (2^14 - 1).
     |  0xE4  |xxxxxxxx|xxxxxxxx|
     +--------+--------+--------+
 
-An integer between 0 and 65,535 (2^16 - 1).
+An integer between 16,384 and 65,535 (2<sup>16</sup> - 1).
 
 #### uint24
 
@@ -146,7 +142,7 @@ An integer between 0 and 65,535 (2^16 - 1).
     |  0xE5  |xxxxxxxx|xxxxxxxx|xxxxxxxx|
     +--------+--------+--------+--------+
 
-An integer between 0 and 16,777,215 (2^24 - 1).
+An integer between 65,536 and 16,777,215 (2<sup>24</sup> - 1).
 
 #### uint32
 
@@ -154,7 +150,7 @@ An integer between 0 and 16,777,215 (2^24 - 1).
     |  0xE6  |xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|
     +--------+--------+--------+--------+--------+
 
-An integer between 0 and 4,294,967,295 (2^32 - 1).
+An integer between 16,777,216 and 4,294,967,295 (2<sup>32</sup> - 1).
 
 #### uint64
 
@@ -162,11 +158,12 @@ An integer between 0 and 4,294,967,295 (2^32 - 1).
     |  0xE7  |xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|
     +--------+--------+--------+--------+--------+--------+--------+--------+--------+
 
-An integer between 0 and 2^64 - 1.
+An integer between 4,294,967,296 and 2<sup>64</sup> - 1.
 
 ### nint family
 
-Stores a big-endian encoding of the magnitude of a non-positive integer in 1, 2, 3, 5, or 9 bytes.
+Stores a big-endian encoding of the magnitude of a non-positive integer in 1,
+2, 3, 5, or 9 bytes.
 
 #### nint4
 
@@ -174,7 +171,7 @@ Stores a big-endian encoding of the magnitude of a non-positive integer in 1, 2,
     |1000xxxx|
     +--------+
 
-An integer between 0 and -15.
+An integer between -1 and -15. The type tag 0x80 is reserved.
 
 #### nint8
 
@@ -182,7 +179,7 @@ An integer between 0 and -15.
     |  0xE8  |xxxxxxxx|
     +--------+--------+
 
-An integer between 0 and -255.
+An integer between -16 and -255.
 
 #### nint16
 
@@ -190,7 +187,7 @@ An integer between 0 and -255.
     |  0xE9  |xxxxxxxx|xxxxxxxx|
     +--------+--------+--------+
 
-An integer between 0 and -65535.
+An integer between -256 and -65,535.
 
 #### nint32
 
@@ -198,7 +195,7 @@ An integer between 0 and -65535.
     |  0xEA  |xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|
     +--------+--------+--------+--------+--------+
 
-An integer between 0 and -4294967295.
+An integer between -65,536 and -4,294,967,295.
 
 #### nint64
 
@@ -206,11 +203,11 @@ An integer between 0 and -4294967295.
     |  0xEB  |xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|
     +--------+--------+--------+--------+--------+--------+--------+--------+--------+
 
-An integer between 0 and -(2^64 - 1).
+An integer between -4,294,967,296 and -(2<sup>64</sup> - 1).
 
 ### float family
 
-Stores a floating point number in 5 or 9 bytes.
+Stores an IEEE-754 floating point number in 5 or 9 bytes.
 
 `s`, `e`, and `m` bits represent sign, exponent, and mantissa, respectively.
 
@@ -230,7 +227,9 @@ Stores a floating point number in 5 or 9 bytes.
 
 #### timestamp
 
-Stores a timestamp (in milliseconds since 1970-01-01T00:00:00.000Z) in 7 bytes. Essentially an `int48`. The first bit is the sign bit and the the bytes are in big-endian order.
+Stores a timestamp (in milliseconds since 1970-01-01T00:00:00.000Z) in 7 bytes.
+Essentially an `int48`. The first bit is the sign bit and the bytes are in
+big-endian order.
 
     +--------+--------+--------+--------+--------+--------+--------+
     |  0xEE  |xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|xxxxxxxx|
@@ -268,7 +267,7 @@ Stores `false`, `true`, `null`, or `undefined` in one byte.
 
 Stores a binary blob.
 
-### binary\*
+#### binary\*
 
     +--------+~~~~~~+=============+
     |  0xEF  | uint | binary data |
@@ -288,18 +287,10 @@ Stores a UTF-8 encoded string.
 
 A string of up to 31 UTF-8 bytes.
 
-#### str8
-
-    +--------+--------+===========+
-    |  0xF1  |xxxxxxxx| utf8 data |
-    +--------+--------+===========+
-
-A string of up to 255 UTF-8 bytes.
-
 #### str\*
 
     +--------+~~~~~~+===========+
-    |  0xF2  | uint | utf8 data |
+    |  0xF1  | uint | utf8 data |
     +--------+~~~~~~+===========+
 
 A string of any `uint` number of UTF-8 bytes.
@@ -310,17 +301,8 @@ A string of any `uint` number of UTF-8 bytes.
     |  0xF0  | utf8 data |  0x00  |
     +--------+===========+--------+
 
-A null-terminated string of any number of UTF-8 bytes. The UTF-8 bytes must not contain `0x00`.
-
-#### strref
-
-    +--------+--------+
-    |  0xF3  |xxxxxxxx|
-    +--------+--------+
-
-The string at index `xxxxxxxx` in the string lookup table.
-
-See also: [Repeated String Optimisation](#repeated-string-optimisation)
+A null-terminated string of any number of UTF-8 bytes. The UTF-8 bytes must not
+contain `0x00`.
 
 ### array family
 
@@ -332,18 +314,10 @@ See also: [Repeated String Optimisation](#repeated-string-optimisation)
 
 An array of up to 31 values.
 
-#### array8
-
-    +--------+--------+~~~~~~~~+
-    |  0xF4  |xxxxxxxx| values |
-    +--------+--------+~~~~~~~~+
-
-An array of up to 255 values.
-
 #### array\*
 
     +--------+~~~~~~+~~~~~~~~+
-    |  0xF5  | uint | values |
+    |  0xF2  | uint | values |
     +--------+~~~~~~+~~~~~~~~+
 
 An array of any `uint` number of values.
@@ -356,30 +330,21 @@ An array of any `uint` number of values.
 
 An array of up to 15 boolean values.
 
-Those boolean values are stored as one bit each, right-padded with `0` bits to the next full byte if necessary.
-`true` is represented as a `1` bit and `false` is represented as a `0` bit.
-
-#### barray8
-
-    +--------+--------+==========+
-    |  0xF6  |xxxxxxxx| booleans |
-    +--------+--------+==========+
-
-An array of up to 255 boolean values.
-
-Those boolean values are stored as one bit each, right-padded with `0` bits to the next full byte if necessary.
-`true` is represented as a `1` bit and `false` is represented as a `0` bit.
+The boolean values of the array are stored as one bit each, right-padded with
+`0` bits to the next full byte if necessary. `true` is represented as a `1`
+bit and `false` is represented as a `0` bit.
 
 #### barray\*
 
     +--------+~~~~~~+==========+
-    |  0xF7  | uint | booleans |
+    |  0xF3  | uint | booleans |
     +--------+~~~~~~+==========+
 
 An array of any `uint` number of boolean values.
 
-Those boolean values are stored as one bit each, right-padded with `0` bits to the next full byte if necessary.
-`true` is represented as a `1` bit and `false` is represented as a `0` bit.
+The boolean values of the array are stored as one bit each, right-padded with
+`0` bits to the next full byte if necessary. `true` is represented as a `1`
+bit and `false` is represented as a `0` bit.
 
 ### map family
 
@@ -388,47 +353,55 @@ Stores a map structure.
 #### map
 
     +--------+~~~~~~+~~~~~~~~+
-    |  0xF8  | uint | values |
+    |  0xF4  | keys | values |
     +--------+~~~~~~+~~~~~~~~+
 
-A map whose keyset is the `uint` index of the keyset table.
-
-The values are stored in the same order as the keys.
-
-See also: [Repeated Keyset Optimisation](#repeated-keyset-optimisation)
+A map whose keys are given by an array of strings. The strings in the array
+must be unique. The values of the map follow in the same order as the keys.
 
 #### bmap
 
-    +--------+~~~~~~+~~~~~~~~+
-    |  0xF9  | uint | values |
-    +--------+~~~~~~+~~~~~~~~+
+    +--------+~~~~~~+==========+
+    |  0xF5  | keys | booleans |
+    +--------+~~~~~~+==========+
 
-A boolean-valued map whose keyset is the `uint` index of the keyset table.
+A boolean-valued map whose keys are given by an array of strings. The strings
+in the array must be unique.
 
-Those boolean values are stored as one bit each, right-padded with `0` bits to the next full byte if necessary, in the same order as the keys.
-`true` is represented as a `1` bit and `false` is represented as a `0` bit.
-
-See also: [Repeated Keyset Optimisation](#repeated-keyset-optimisation)
-
-#### mapl
-
-Map literal, for implementations which do not use repeated keyset optimisation. Format TBD.
-
-#### bmapl
-
-Boolean-valued map literal, for implementations which do not use repeated keyset optimisation. Format TBD.
+The boolean values of the map are stored as one bit each, right-padded with `0`
+bits to the next full byte if necessary, in the same order as the keys. `true`
+is represented as a `1` bit and `false` is represented as a `0` bit.
 
 ### extension family
+
+Represents an otherwise unsupported value in terms of a supported value,
+identified by the extension point. For more information, see [Extensions](#extensions).
+
+#### extension3
+
+    +--------+~~~~~~~+
+    |11111xxx| value |
+    +--------+~~~~~~~+
+
+An extension point between 0 and 7 followed by any SuperPack value.
 
 #### extension\*
 
     +--------+~~~~~~+~~~~~~~+
-    |  0xFF  | uint | value |
+    |  0xF7  | uint | value |
     +--------+~~~~~~+~~~~~~~+
 
-A `uint` extension point followed by any single value. Represents an otherwise unsupported value in terms of a supported value, identified by the extension point.
+A `uint` extension point followed by any SuperPack value.
 
-Encoders are expected to provide an interface for a consumer to specify a serialisation and deserialisation mechanism for a given type of data.
+## Extensions
+
+SuperPack encoders should provide an interface for a consumer to specify a
+serialisation and deserialisation mechanism for a given type of data. For
+example, since SuperPack does not have built-in support for representation of
+regular expressions, a regular expression may instead be represented as a
+two-element array containing its source and flags. When the SuperPack value
+that represents this intermediate value is decoded, it will be converted back
+to a regular expression.
 
 ```js
 let transcoder = new SuperPackTranscoder;
@@ -444,68 +417,60 @@ transcoder.extend(
 );
 ```
 
+A SuperPack encoder must not recursively apply an extension when encoding the
+result of its own serialisation.
 
-## Optimisations
+### Extension memos
 
-The SuperPack spec supports two optimisations: the *repeated string optimisation* and the *repeated keyset optimisation*. These are enabled by the string lookup table and the keyset lookup table.
+Extension memos allow for the storage of a side table used in the decoding of
+values encoded by an extension. This is mostly useful for deduplication and
+optimisation.
 
-If the first byte of a payload **is not** the `opts` type tag, the payload does not use repetition optimisations and consists of just one part, the encoded data value.
+```js
+let symbols = [];
+let decodedSymbols = [];
 
-    +~~~~~~~+
-    | value |
-    +~~~~~~~+
+// preserves ECMAScript Symbol identity and description
+let symbolExtension = {
+  detector: x => typeof x === 'symbol',
+  serialiser(s) {
+    let i = symbols.indexOf(s);
+    if (i >= 0) return i;
+    return symbols.push(s) - 1;
+  },
+  deserialiser(n, memo) {
+    if (decodedSymbols[n] == null) {
+      let s = Symbol(memo[n]);
+      decodedSymbols[n] = s;
+      return s;
+    } else {
+      return decodedSymbols[n];
+    }
+  },
+  memo: () => symbols.map(sym => String(sym).slice(7, -1)),
+};
 
-If the first byte of a payload **is** the `opts` type tag, the payload uses repetition optimisations, and is constructed from the following parts concatenated together:
+let encoded = encode(data, { extensions: { 0: symbolExtension } });
+```
 
-    +--------+~~~~~~~~~~~~~~~~~~~~~+~~~~~~~~~~~~~~~~~~~~~+~~~~~~~+
-    |  0xFE  | string lookup table | keyset lookup table | value |
-    +--------+~~~~~~~~~~~~~~~~~~~~~+~~~~~~~~~~~~~~~~~~~~~+~~~~~~~+
+Memos are only prepended for extensions that define the optional `memo`
+function. Memos are encoded and prepended to the SuperPack payload in
+descending extension point order. During the encoding of a memo, extensions
+that define the optional `memo` function must not be applied if their extension
+point is greater than that of the extension whose memo is being encoded.
 
-0. The `opts` type tag, `0xFE`.
-1. The *string lookup table*, for repeated string optimisation. This value is an `array8` (sans type tag) containing strings which occur at least twice in the parts that follow. If the repeated keyset optimisation is used but the string lookup table is empty, it must be explicitly included as the length `0`.
+#### Examples
 
-        +--------+~~~~~~~~~+
-        |xxxxxxxx| strings |
-        +--------+~~~~~~~~~+
+* String deduplication
+* Map keyset deduplication
+* Representation of values with identity
+* Deduplication of common integers, timestamps, floats, or other potentially large data types
 
-2. The *keyset lookup table*, for repeated keyset optimisation, possibly containing references to (1). This value is an array of any length, containing any number of arrays of strings, each such array representing an ordered keyset and containing no repeated strings. If the repeated string optimisation is used but the keyset lookup table is empty, it must be explicitly included as an empty array.
-3. The *encoded value*, possibly containing references to (1) and (2). This can be of any type.
+... and many domain-specific usages.
 
-The `opts` type tag MUST NOT be used anywhere else except for at the beginning of an optimised form payload.
+#### Precautions
 
-We might like for an encoder to always output the shortest possible payload for a given value, whichever form that may be. The most accurate way to determine this is to encode the input value to both forms and return the shorter one, but this is rather laborious. Much simpler determinations can be correct in almost all cases, and an optimised form payload will almost never be more than a few bytes larger than the equivalent simple form payload. For these reasons, the spec writers consider it reasonable to use the optimised form whenever the payload contains a map or repeated string, and to use the simple form otherwise. This rule of thumb allows for some uncommon cases where the optimised form is used when the simple form would be smaller, but it allows for a much easier determination, will never miss an optimisation, and still avoids using the optimised form when it just adds an obviously-useless 3-byte prefix of `opts 0 array5` to the equivalent simple form.
-
-### Repeated String Optimisation
-
-The string lookup table stores strings which occur multiple times, allowing them to be referenced by the `strref` type tag so repeated instances each take constant space regardless of the size of the string.
-
-Specifically, the string lookup table has a maximum size of 255, so as to guarantee that a string reference requires only two bytes.
-
-### Repeated Keyset Optimisation
-
-TODO: explain
-
-### Precautions
-
-As with any compression-like scheme, highly-compressed inputs which result in a much larger decoded value are a concern.
-
-For SuperPack payloads crafted for maximum expansion, the following relationships between input size and expanded size hold:
-
-| Input Size | Expanded Size |
-| ---------- | ------------- |
-| 1kB        | 125kB         |
-| 2kB        | 500kB         |
-| 2.83kB     | 1mB           |
-| 4kB        | 2mB           |
-| 40kB       | 200mB         |
-| 400kB      | 20gB          |
-
-In general, doubling the size of the payload will quadruple the potential size of the expanded value, and a `b`-byte input will expand to `(b * b) / 8` bytes.
-
-The general form of a maximally-expanding payload is an array of `b/4` copies of a single string of length `b/2`. The repeated string optimisation allows each copy to require only 2 bytes, so the payload encodes to `(b / 4) * 2` bytes for the array and `b/2` bytes for the string, plus a few bytes of constant overhead. Thus, we have a `b`-byte input expanding to `(b / 4) * (b / 2)` bytes.
-
-A similar expansion can be done using just the repeated keyset optimisation, but it is less efficient, expanding `b` bytes to `(b * b) / 12` bytes.
-
-There's no way to achieve greater expansion by stacking the two optimisations, largely because SuperPack maps have unique keys. The closest structure using both optimisations would be an array of 1-element maps, each mapping the same particular long string to itself. This would use 4 bytes per such map (1 byte map type tag, 1 byte keyset index, 2 bytes string reference), achieving no greater efficiency than replacing each map with two copies of that string, which leads to the `(b * b) / 8` expansion described above.
-
-SuperPack decoders SHOULD assume their input is potentially adversarial and be resistant to this expansion attack.
+As with any compression-like scheme, highly-compressed inputs which result in a
+much larger decoded value are a concern. SuperPack decoders are advised to
+assume that their input is potentially adversarial and be resistant to attacks
+based on expansion.

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ from the [New York Public Library Digital Collections API](http://api.repo.nypl.
 
 | name                                                                 | encoded size | gzip compressed | extensible    | rich built-in types | human-readable |
 | -------------------------------------------------------------------- | -----------: | --------------: | ----------    | ------------------- | -------------- |
-| *SuperPack*<sup>1</sup>                                              |      768121B |         225789B | YES           | no                  | no             |
-| [Sereal](https://github.com/Sereal/Sereal)                           |     1442191B |         268279B | YES           | no                  | no             |
-| [MessagePack](http://msgpack.org)                                    |     2019749B |         271652B | YES           | no                  | no             |
-| *SuperPack*<sup>2</sup>                                              |     2024460B |         264545B | YES           | no                  | no             |
-| [CBOR](http://cbor.io/)                                              |     2025561B |         270380B | YES           | YES                 | no             |
-| [ARSON](https://github.com/benjamn/arson)                            |     2048144B |         361479B | theoretically | YES                 | arguably       |
-| [bencode](https://wiki.theory.org/BitTorrentSpecification#Bencoding) |     2208153B |         273791B | no            | no                  | arguably       |
-| [edn](https://github.com/edn-format/edn)                             |     2257810B |         261175B | YES           | no                  | YES            |
-| [JSON](http://www.json.org/)                                         |     2275987B |         260878B | no            | no                  | arguably       |
-| [BSON](http://bsonspec.org/)                                         |     2353043B |         314438B | YES           | YES                 | no             |
-| [YAML](http://yaml.org/)                                             |     2444730B |         275741B | YES           | no                  | YES            |
+| *SuperPack*<sup>1</sup>                                              |      768.1KB |         225.8KB | YES           | no                  | no             |
+| [Sereal](https://github.com/Sereal/Sereal)                           |     1442.2KB |         268.3KB | YES           | no                  | no             |
+| [MessagePack](http://msgpack.org)                                    |     2019.7KB |         271.7KB | YES           | no                  | no             |
+| *SuperPack*<sup>2</sup>                                              |     2024.5KB |         264.5KB | YES           | no                  | no             |
+| [CBOR](http://cbor.io/)                                              |     2025.6KB |         270.4KB | YES           | YES                 | no             |
+| [ARSON](https://github.com/benjamn/arson)                            |     2048.1KB |         361.5KB | theoretically | YES                 | arguably       |
+| [bencode](https://wiki.theory.org/BitTorrentSpecification#Bencoding) |     2208.2KB |         273.8KB | no            | no                  | arguably       |
+| [edn](https://github.com/edn-format/edn)                             |     2257.8KB |         261.2KB | YES           | no                  | YES            |
+| [JSON](http://www.json.org/)                                         |     2276.0KB |         260.9KB | no            | no                  | arguably       |
+| [BSON](http://bsonspec.org/)                                         |     2353.0KB |         314.4KB | YES           | YES                 | no             |
+| [YAML](http://yaml.org/)                                             |     2444.7KB |         275.7KB | YES           | no                  | YES            |
 
 
 SuperPack is designed to

--- a/comparison/comparison.js
+++ b/comparison/comparison.js
@@ -1,5 +1,6 @@
 let fs = require('fs');
 
+let ARSON = require('arson');
 let bencode = require('bencode-js');
 let BSON = require('bson');
 let edn = require('edn')
@@ -27,6 +28,7 @@ const file = 'node_modules/public-domain-nypl-captures/data/pd_items.ndjson';
 let data = Array.from(lines(fs.readFileSync(file))).slice(0, 1000).map(JSON.parse);
 
 let results = {
+  ARSON: ARSON.encode(data),
   JSON: JSON.stringify(data, null, 0),
   BSON: new BSON().serialize(data),
   'SuperPack (built-in optimisations)': superpack.encode(data, { extensions: superpack.default.recommendedOptimisations }),

--- a/comparison/comparison.js
+++ b/comparison/comparison.js
@@ -1,7 +1,7 @@
 let fs = require('fs');
 
 let bencode = require('bencode-js');
-let bson = require('bson');
+let BSON = require('bson');
 let edn = require('edn')
 let msgpack = require('msgpack');
 let superpack = require('superpack');
@@ -28,8 +28,9 @@ let data = Array.from(lines(fs.readFileSync(file))).slice(0, 1000).map(JSON.pars
 
 let results = {
   JSON: JSON.stringify(data, null, 0),
-  BSON: new bson.BSONPure.BSON().serialize(data),
-  SuperPack: superpack.encode(data),
+  BSON: new BSON().serialize(data),
+  'SuperPack (built-in optimisations)': superpack.encode(data, { extensions: superpack.default.recommendedOptimisations }),
+  'SuperPack (no optimisations)': superpack.encode(data),
   MessagePack: msgpack.pack(data),
   bencode: bencode.encode(data),
   edn: edn.stringify(data),

--- a/comparison/package.json
+++ b/comparison/package.json
@@ -7,13 +7,14 @@
   "author": "Michael Ficarra",
   "license": "Apache-2.0",
   "dependencies": {
-    "bencode-js": "0.0.7",
-    "bson": "^0.5.2",
+    "arson": "^0.2.5",
+    "bencode-js": "0.0.8",
+    "bson": "^1.0.4",
     "cbor-sync": "^1.0.2",
-    "edn": "git@github.com:josh/js-edn.git#c74878462f655659e77d7d847e75973f73cf4e80",
+    "edn": "git+ssh://git@github.com/josh/js-edn.git#c74878462f655659e77d7d847e75973f73cf4e80",
     "js-yaml": "^3.6.1",
     "msgpack": "^1.0.2",
     "public-domain-nypl-captures": "1.1.0",
-    "superpack": "shapesecurity/superpack-js#master"
+    "superpack": "github:shapesecurity/superpack-js#master"
   }
 }


### PR DESCRIPTION
Also remove built-in optimisations. Implementations will provide their own standard optimisations. I'll update the comparison table once I pull out the optimisations into standard extensions in superpack-js.